### PR TITLE
Use local ID generator for plan blocks

### DIFF
--- a/components/NewBlockButton.tsx
+++ b/components/NewBlockButton.tsx
@@ -5,10 +5,7 @@ import Button from './ui/Button'
 import { useTimeBoxStore } from '@/lib/store'
 import { PlanBlock } from '@/lib/types'
 import { createISODateTime } from '@/lib/time'
-
-function uuid() {
-  return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
-}
+import { generateBlockId } from '@/lib/id'
 
 export default function NewBlockButton() {
   const { selectedDate, startHour, addPlanBlock, setSelectedBlockId } = useTimeBoxStore()
@@ -25,7 +22,7 @@ export default function NewBlockButton() {
     const endDateTime = endDate.toISOString()
 
     const newBlock: PlanBlock = {
-      id: uuid(),
+      id: generateBlockId(),
       title: 'Focus Block',
       start: startDateTime,
       end: endDateTime,

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -5,10 +5,7 @@ import { useTimeBoxStore } from '@/lib/store'
 import { generateHourLabels, createISODateTime, parseISO } from '@/lib/time'
 import TimeBlock from './TimeBlock'
 import { PlanBlock } from '@/lib/types'
-
-function uuid() {
-  return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
-}
+import { generateBlockId } from '@/lib/id'
 
 export default function Timeline() {
   const {
@@ -47,7 +44,7 @@ export default function Timeline() {
     const endDateTime = endDate.toISOString()
 
     const newBlock: PlanBlock = {
-      id: uuid(),
+      id: generateBlockId(),
       title: 'Focus Block',
       start: startDateTime,
       end: endDateTime,

--- a/lib/id.ts
+++ b/lib/id.ts
@@ -1,0 +1,10 @@
+export function generateBlockId(): string {
+  const hasCrypto = typeof globalThis === 'object' && 'crypto' in globalThis
+  const cryptoObj = hasCrypto ? globalThis.crypto : undefined
+
+  if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+    return cryptoObj.randomUUID()
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
+}


### PR DESCRIPTION
## Summary
- add a shared block id utility that uses `crypto.randomUUID` when available and falls back to a timestamp-based id
- update the timeline and new block button to call the new helper instead of the removed `uuid` dependency

## Testing
- npm run lint
- npm run build *(fails: NextFontError while fetching Inter from Google Fonts in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913b20064908324a0db74b2c30c7be0)