### PR TITLE
Enable drag and resize functionality for plan blocks

### DIFF
--- a/components/HelpModal.tsx
+++ b/components/HelpModal.tsx
@@ -38,7 +38,7 @@ export default function HelpModal({ isOpen, onClose }: HelpModalProps) {
               <span className="font-semibold text-blue-600">2.</span>
               <div>
                 <strong>Create plan blocks:</strong> Click anywhere on the timeline or use the
-                &ldquo;+ New Block&rdquo; button to add focused work time. Click blocks to edit them.
+                &quot;+ New Block&quot; button to add focused work time. Click blocks to edit them.
               </div>
             </li>
             <li className="flex gap-3">

--- a/components/TimeBlock.tsx
+++ b/components/TimeBlock.tsx
@@ -2,7 +2,8 @@
 
 import React from 'react'
 import { BusyEvent, PlanBlock } from '@/lib/types'
-import { getTimePosition, getHeight, formatTime, parseISO } from '@/lib/time'
+import { getTimePosition, getHeight, formatTime } from '@/lib/time'
+import { useTimeBoxStore } from '@/lib/store'
 
 interface TimeBlockProps {
   event: BusyEvent | PlanBlock
@@ -21,27 +22,56 @@ export default function TimeBlock({
   onClick,
   hasConflict = false,
 }: TimeBlockProps) {
+  const { startDrag, isDragging, draggedBlockId } = useTimeBoxStore()
+  
   const top = getTimePosition(event.start, startHour, endHour)
   const height = getHeight(event.start, event.end, startHour, endHour)
   
   const startTime = formatTime(event.start)
   const endTime = formatTime(event.end)
 
-  const baseStyles = 'absolute left-0 right-0 mx-1 rounded-md px-2 py-1 text-sm overflow-hidden transition-all cursor-pointer'
+  const isBeingDragged = isDragging && draggedBlockId === event.id
+  const isPlanBlock = type === 'plan'
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (!isPlanBlock) return
+    
+    // Prevent if clicking on resize handle
+    const target = e.target as HTMLElement
+    if (target.classList.contains('resize-handle')) return
+    
+    e.stopPropagation()
+    startDrag(event.id, 'move', event.start, event.end)
+  }
+
+  const handleResizeTopMouseDown = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    startDrag(event.id, 'resize-top', event.start, event.end)
+  }
+
+  const handleResizeBottomMouseDown = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    startDrag(event.id, 'resize-bottom', event.start, event.end)
+  }
+
+  const baseStyles = 'absolute left-0 right-0 mx-1 rounded-md px-2 py-1 text-sm overflow-hidden transition-all'
   const typeStyles = type === 'busy' 
-    ? 'bg-gray-200 text-gray-700 border border-gray-300'
-    : 'bg-blue-500 text-white border-2 border-blue-600 hover:bg-blue-600'
+    ? 'bg-gray-200 text-gray-700 border border-gray-300 cursor-default'
+    : 'bg-blue-500 text-white border-2 border-blue-600 hover:bg-blue-600 cursor-move'
   
   const conflictStyles = hasConflict ? 'ring-2 ring-red-500 ring-offset-1' : ''
+  const dragStyles = isBeingDragged ? 'opacity-70 border-dashed' : ''
 
   return (
     <div
-      className={`${baseStyles} ${typeStyles} ${conflictStyles}`}
+      className={`${baseStyles} ${typeStyles} ${conflictStyles} ${dragStyles}`}
       style={{
         top: `${top}%`,
         height: `${height}%`,
         minHeight: '30px',
+        pointerEvents: isDragging && !isBeingDragged ? 'none' : 'auto',
       }}
+      onMouseDown={handleMouseDown}
       onClick={onClick}
       role="button"
       tabIndex={0}
@@ -52,12 +82,30 @@ export default function TimeBlock({
       }}
       aria-label={`${type === 'busy' ? 'Busy' : 'Plan'} block: ${event.title} from ${startTime} to ${endTime}`}
     >
+      {/* Top resize handle - only for plan blocks */}
+      {isPlanBlock && (
+        <div
+          className="resize-handle absolute top-0 left-0 right-0 h-2 cursor-n-resize hover:bg-blue-400 hover:opacity-50 transition-opacity"
+          onMouseDown={handleResizeTopMouseDown}
+          aria-label="Resize top"
+        />
+      )}
+
       <div className="font-semibold truncate">{event.title}</div>
       <div className="text-xs opacity-90">
         {startTime} - {endTime}
       </div>
       {event.location && (
         <div className="text-xs opacity-75 truncate">📍 {event.location}</div>
+      )}
+
+      {/* Bottom resize handle - only for plan blocks */}
+      {isPlanBlock && (
+        <div
+          className="resize-handle absolute bottom-0 left-0 right-0 h-2 cursor-s-resize hover:bg-blue-400 hover:opacity-50 transition-opacity"
+          onMouseDown={handleResizeBottomMouseDown}
+          aria-label="Resize bottom"
+        />
       )}
     </div>
   )

--- a/lib/drag-utils.ts
+++ b/lib/drag-utils.ts
@@ -1,0 +1,228 @@
+import { parseISO } from 'date-fns'
+
+/**
+ * Snap time (in minutes) to nearest interval
+ * @param minutes Total minutes from start of day
+ * @param interval Snap interval in minutes (default 15)
+ */
+export function snapToInterval(minutes: number, interval: number = 15): number {
+  return Math.round(minutes / interval) * interval
+}
+
+/**
+ * Convert Y position on timeline to time (in minutes from start of day)
+ * @param yPosition Mouse Y position relative to timeline container
+ * @param containerHeight Height of timeline container
+ * @param startHour Timeline start hour (e.g., 8)
+ * @param endHour Timeline end hour (e.g., 18)
+ */
+export function getTimeFromPosition(
+  yPosition: number,
+  containerHeight: number,
+  startHour: number,
+  endHour: number
+): number {
+  const totalHours = endHour - startHour
+  const totalMinutes = totalHours * 60
+  
+  // Calculate percentage down the timeline
+  const percentage = yPosition / containerHeight
+  
+  // Convert to minutes from start of timeline
+  const minutesFromStart = percentage * totalMinutes
+  
+  // Add start hour offset to get absolute minutes from midnight
+  const absoluteMinutes = startHour * 60 + minutesFromStart
+  
+  return snapToInterval(absoluteMinutes)
+}
+
+/**
+ * Calculate new block times when dragging (moving the entire block)
+ * @param dragStartY Initial mouse Y position when drag started
+ * @param currentY Current mouse Y position
+ * @param originalStart Original block start time (ISO string)
+ * @param originalEnd Original block end time (ISO string)
+ * @param containerHeight Height of timeline container
+ * @param startHour Timeline start hour
+ * @param endHour Timeline end hour
+ * @param selectedDate Current selected date
+ */
+export function calculateDraggedTime(
+  dragStartY: number,
+  currentY: number,
+  originalStart: string,
+  originalEnd: string,
+  containerHeight: number,
+  startHour: number,
+  endHour: number,
+  selectedDate: Date
+): { start: string; end: string } {
+  // Calculate the offset in minutes
+  const deltaY = currentY - dragStartY
+  const totalHours = endHour - startHour
+  const totalMinutes = totalHours * 60
+  const deltaMinutes = (deltaY / containerHeight) * totalMinutes
+  const snappedDelta = snapToInterval(deltaMinutes)
+  
+  // Apply offset to both start and end times
+  const originalStartDate = parseISO(originalStart)
+  const originalEndDate = parseISO(originalEnd)
+  
+  const newStartDate = new Date(originalStartDate)
+  newStartDate.setMinutes(newStartDate.getMinutes() + snappedDelta)
+  
+  const newEndDate = new Date(originalEndDate)
+  newEndDate.setMinutes(newEndDate.getMinutes() + snappedDelta)
+  
+  // Constrain to timeline bounds
+  const constrainedStart = constrainToTimeline(
+    newStartDate.toISOString(),
+    startHour,
+    endHour,
+    selectedDate
+  )
+  
+  // Calculate duration and apply to constrained start
+  const duration = originalEndDate.getTime() - originalStartDate.getTime()
+  const constrainedStartDate = parseISO(constrainedStart)
+  const constrainedEndDate = new Date(constrainedStartDate.getTime() + duration)
+  
+  const constrainedEnd = constrainToTimeline(
+    constrainedEndDate.toISOString(),
+    startHour,
+    endHour,
+    selectedDate
+  )
+  
+  return {
+    start: constrainedStart,
+    end: constrainedEnd,
+  }
+}
+
+/**
+ * Calculate new block times when resizing (adjusting start or end time)
+ * @param mode 'resize-top' or 'resize-bottom'
+ * @param currentY Current mouse Y position
+ * @param originalStart Original block start time (ISO string)
+ * @param originalEnd Original block end time (ISO string)
+ * @param containerHeight Height of timeline container
+ * @param startHour Timeline start hour
+ * @param endHour Timeline end hour
+ * @param selectedDate Current selected date
+ */
+export function calculateResizedTime(
+  mode: 'resize-top' | 'resize-bottom',
+  currentY: number,
+  originalStart: string,
+  originalEnd: string,
+  containerHeight: number,
+  startHour: number,
+  endHour: number,
+  selectedDate: Date
+): { start: string; end: string } {
+  const newTimeMinutes = getTimeFromPosition(
+    currentY,
+    containerHeight,
+    startHour,
+    endHour
+  )
+  
+  const newDate = new Date(selectedDate)
+  newDate.setHours(Math.floor(newTimeMinutes / 60))
+  newDate.setMinutes(newTimeMinutes % 60)
+  newDate.setSeconds(0)
+  newDate.setMilliseconds(0)
+  
+  const originalStartDate = parseISO(originalStart)
+  const originalEndDate = parseISO(originalEnd)
+  
+  if (mode === 'resize-top') {
+    // Adjusting start time, keep end time fixed
+    const minDuration = 15 // minimum 15 minutes
+    const maxStart = new Date(originalEndDate)
+    maxStart.setMinutes(maxStart.getMinutes() - minDuration)
+    
+    let newStart = newDate.toISOString()
+    
+    // Don't let start go past end (minus minimum duration)
+    if (newDate > maxStart) {
+      newStart = maxStart.toISOString()
+    }
+    
+    // Constrain to timeline
+    newStart = constrainToTimeline(newStart, startHour, endHour, selectedDate)
+    
+    return {
+      start: newStart,
+      end: originalEnd,
+    }
+  } else {
+    // mode === 'resize-bottom'
+    // Adjusting end time, keep start time fixed
+    const minDuration = 15 // minimum 15 minutes
+    const minEnd = new Date(originalStartDate)
+    minEnd.setMinutes(minEnd.getMinutes() + minDuration)
+    
+    let newEnd = newDate.toISOString()
+    
+    // Don't let end go before start (plus minimum duration)
+    if (newDate < minEnd) {
+      newEnd = minEnd.toISOString()
+    }
+    
+    // Constrain to timeline
+    newEnd = constrainToTimeline(newEnd, startHour, endHour, selectedDate)
+    
+    return {
+      start: originalStart,
+      end: newEnd,
+    }
+  }
+}
+
+/**
+ * Constrain a time to stay within timeline bounds
+ * @param timeStr ISO time string
+ * @param startHour Timeline start hour
+ * @param endHour Timeline end hour
+ * @param selectedDate Current selected date
+ */
+export function constrainToTimeline(
+  timeStr: string,
+  startHour: number,
+  endHour: number,
+  selectedDate: Date
+): string {
+  const time = parseISO(timeStr)
+  const date = new Date(selectedDate)
+  
+  // Set minimum bound (start hour)
+  const minTime = new Date(date)
+  minTime.setHours(startHour, 0, 0, 0)
+  
+  // Set maximum bound (end hour)
+  const maxTime = new Date(date)
+  maxTime.setHours(endHour, 0, 0, 0)
+  
+  if (time < minTime) {
+    return minTime.toISOString()
+  }
+  
+  if (time > maxTime) {
+    return maxTime.toISOString()
+  }
+  
+  return timeStr
+}
+
+/**
+ * Get duration in minutes between two times
+ */
+export function getDurationMinutes(start: string, end: string): number {
+  const startDate = parseISO(start)
+  const endDate = parseISO(end)
+  return Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60))
+}
+

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -29,6 +29,15 @@ interface TimeBoxStore {
   // UI state
   selectedBlockId: string | null
   setSelectedBlockId: (id: string | null) => void
+
+  // Drag state
+  isDragging: boolean
+  draggedBlockId: string | null
+  dragMode: 'move' | 'resize-top' | 'resize-bottom' | null
+  dragOriginalStart: string | null
+  dragOriginalEnd: string | null
+  startDrag: (blockId: string, mode: 'move' | 'resize-top' | 'resize-bottom', start: string, end: string) => void
+  endDrag: () => void
 }
 
 export const useTimeBoxStore = create<TimeBoxStore>()(
@@ -42,6 +51,11 @@ export const useTimeBoxStore = create<TimeBoxStore>()(
       planBlocks: [],
       conflicts: [],
       selectedBlockId: null,
+      isDragging: false,
+      draggedBlockId: null,
+      dragMode: null,
+      dragOriginalStart: null,
+      dragOriginalEnd: null,
 
       // Actions
       setSelectedDate: (date) => set({ selectedDate: date }),
@@ -69,6 +83,24 @@ export const useTimeBoxStore = create<TimeBoxStore>()(
 
       setConflicts: (conflicts) => set({ conflicts }),
       setSelectedBlockId: (id) => set({ selectedBlockId: id }),
+
+      startDrag: (blockId, mode, start, end) =>
+        set({
+          isDragging: true,
+          draggedBlockId: blockId,
+          dragMode: mode,
+          dragOriginalStart: start,
+          dragOriginalEnd: end,
+        }),
+      
+      endDrag: () =>
+        set({
+          isDragging: false,
+          draggedBlockId: null,
+          dragMode: null,
+          dragOriginalStart: null,
+          dragOriginalEnd: null,
+        }),
     }),
     {
       name: 'timebox-storage',

--- a/lib/time.ts
+++ b/lib/time.ts
@@ -1,7 +1,7 @@
 import { format, parse, parseISO, isToday as isTodayFn, startOfDay, endOfDay } from 'date-fns'
 
-// Re-export parseISO for use in components
-export { parseISO }
+// Re-export parseISO for use in other components
+export { parseISO } from 'date-fns'
 
 export function formatTime(date: Date | string): string {
   const d = typeof date === 'string' ? parseISO(date) : date

--- a/types/ical.js.d.ts
+++ b/types/ical.js.d.ts
@@ -1,0 +1,9 @@
+declare module 'ical.js' {
+  export default class ICAL {
+    static parse(input: string): any
+    static Component: any
+    static Event: any
+    static Time: any
+  }
+}
+


### PR DESCRIPTION
Features:
- Drag blocks up/down to change their start time
- Resize blocks by dragging top/bottom edges to adjust duration
- Visual feedback: opacity, dashed borders, live tooltip showing time/duration
- All interactions snap to 15-minute intervals
- Blocks constrained to timeline bounds with minimum 15-minute duration

Technical changes:
- Added lib/drag-utils.ts: Position/time calculations and constraint logic
- Updated lib/store.ts: Added drag state management (isDragging, dragMode, etc.)
- Updated lib/time.ts: Export parseISO for use in components
- Updated components/TimeBlock.tsx: Added drag handlers and resize handles
- Updated components/Timeline.tsx: Document-level mouse tracking and tooltip
- Updated components/HelpModal.tsx: Escaped quotes to fix ESLint errors
- Added types/ical.js.d.ts: TypeScript declarations for ical.js module

Fixes:
- Export parseISO to resolve import errors
- Add type declarations for ical.js to fix TypeScript build errors
- Escape apostrophes and quotes in HelpModal for ESLint compliance