### PR TITLE
Add timebox backlog archive sweep (Phase 7, #21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ These commands read and write `$OBSIDIAN_VAULT_PATH/backlog/inbox.md` — the sa
 | `timebox backlog remove --id <id>` | Delete the item block from the inbox |
 | `timebox backlog complete --id <id>` | Flip `[ ]` → `[x]` and stamp `completed::` |
 | `timebox backlog migrate [--dry-run]` | One-time import of legacy `~/.timebox/backlog.json` into the inbox; renames the JSON to `.bak` (dedupes by id, safe to re-run) |
+| `timebox backlog archive [--older-than-days N] [--dry-run]` | Sweep `[x]`-completed items older than N days (default 30) out of `inbox.md` into `$OBSIDIAN_VAULT_PATH/backlog/archive/<year>.md`. Ages by `completed::` (falls back to `captured::`); items with neither date are left in place. Safe to re-run. |
 
 `status` is represented in markdown as: pending (unchecked, no `status::`), scheduled (`status:: scheduled`), completed (`- [x]` checkbox + `completed::` date). `category` and `preferredWindow` from the old JSON model are dropped — the synthesizer reads tags + fields only.
 
@@ -229,7 +230,7 @@ For a *weekly* request, the Weekly Planning Workflow above still applies — `pl
   - `cli/catalog-store.ts` — Code catalog persistence (~/.timebox/code-catalog.json)
   - `cli/inbox-store.ts` — Obsidian inbox.md parser/writer (canonical backlog store; shared by capture, backlog, refine, and the plan-day synthesizer)
   - `cli/types.ts` — CLI-specific types
-  - `cli/commands/` — Command implementations (weather, workout, calendar, schedule, context, backlog, backlog-migrate, week, catalog, capture, refine, plan-day)
+  - `cli/commands/` — Command implementations (weather, workout, calendar, schedule, context, backlog, backlog-migrate, backlog-archive, week, catalog, capture, refine, plan-day)
 - `lib/time-budgets.ts` — Domain → prep/recovery profiles consumed by the plan-day synthesizer
 
 ## Environment Variables

--- a/cli/commands/backlog-archive.ts
+++ b/cli/commands/backlog-archive.ts
@@ -1,0 +1,210 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { getInboxPath, readInbox, writeAtomic } from '../inbox-store'
+
+// Periodic sweep that moves completed (`- [x]`) items out of the working
+// inbox.md and into a yearly archive file under
+// $OBSIDIAN_VAULT_PATH/backlog/archive/<year>.md. Completed work doesn't need
+// to clutter the file the refine/plan-day passes read every command, but it's
+// worth keeping for retrospectives and weekly reviews — so we move, not delete.
+//
+// Eligibility is by age: an item is archived once its reference date is at
+// least `olderThanDays` days in the past. The reference date is the item's
+// `completed::` field, falling back to `captured::` when completion wasn't
+// stamped. Items with neither date can't be aged safely, so they're left in
+// place and surfaced in the result.
+
+export interface ArchivedItem {
+  id: string
+  title: string
+  date: string
+  year: string
+  ageDays: number
+  archiveFile: string
+}
+
+export interface SkippedRecent {
+  id: string
+  title: string
+  date: string
+  ageDays: number
+}
+
+export interface SkippedNoDate {
+  id: string
+  title: string
+}
+
+export interface ArchiveResult {
+  inboxPath: string
+  archiveDir: string
+  olderThanDays: number
+  dryRun: boolean
+  archived: ArchivedItem[]
+  skippedRecent: SkippedRecent[]
+  skippedNoDate: SkippedNoDate[]
+  byFile: Record<string, number>
+}
+
+function getArchiveDir(): string {
+  // backlog/inbox.md -> backlog/archive
+  return path.join(path.dirname(getInboxPath()), 'archive')
+}
+
+function todayUTC(): Date {
+  const d = new Date()
+  return new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()))
+}
+
+const DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/
+
+function parseISODate(value: string): Date | null {
+  const m = value.match(DATE_RE)
+  if (!m) return null
+  const year = Number(m[1])
+  const month = Number(m[2])
+  const day = Number(m[3])
+  const d = new Date(Date.UTC(year, month - 1, day))
+  // Reject impossible dates (e.g. 2026-13-40 rolling over).
+  if (
+    d.getUTCFullYear() !== year ||
+    d.getUTCMonth() !== month - 1 ||
+    d.getUTCDate() !== day
+  ) {
+    return null
+  }
+  return d
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+function ageInDays(date: Date, now: Date): number {
+  return Math.floor((now.getTime() - date.getTime()) / MS_PER_DAY)
+}
+
+export function archiveBacklog(opts: { olderThanDays?: number; dryRun?: boolean } = {}): ArchiveResult {
+  const olderThanDays = opts.olderThanDays ?? 30
+  const dryRun = !!opts.dryRun
+  const archiveDir = getArchiveDir()
+  const { path: inboxPath, lines, items } = readInbox()
+  const now = todayUTC()
+
+  const result: ArchiveResult = {
+    inboxPath,
+    archiveDir,
+    olderThanDays,
+    dryRun,
+    archived: [],
+    skippedRecent: [],
+    skippedNoDate: [],
+    byFile: {},
+  }
+
+  // Collect the line ranges to drop from the inbox and the block text to append
+  // to each year's archive file. We do this in a single pass and rewrite once,
+  // so item ids (content hashes) can't drift mid-sweep.
+  const deleteLines = new Set<number>()
+  const appendByFile = new Map<string, string[]>()
+
+  for (const item of items) {
+    if (!item.done) continue
+
+    const dateStr = item.fields.completed || item.fields.captured || ''
+    const refDate = dateStr ? parseISODate(dateStr) : null
+    if (!refDate) {
+      result.skippedNoDate.push({ id: item.id, title: item.title })
+      continue
+    }
+
+    const age = ageInDays(refDate, now)
+    if (age < olderThanDays) {
+      result.skippedRecent.push({ id: item.id, title: item.title, date: dateStr, ageDays: age })
+      continue
+    }
+
+    const year = dateStr.slice(0, 4)
+    const archiveFile = path.join(archiveDir, `${year}.md`)
+
+    const block = lines.slice(item.startLine, item.endLine + 1)
+    const bucket = appendByFile.get(archiveFile) || []
+    bucket.push(block.join('\n'))
+    appendByFile.set(archiveFile, bucket)
+
+    // Drop the item's lines and one trailing blank separator, mirroring
+    // writeInboxRemove so we don't leave double blank lines behind.
+    for (let i = item.startLine; i <= item.endLine; i++) deleteLines.add(i)
+    if (item.endLine + 1 < lines.length && lines[item.endLine + 1].trim() === '') {
+      deleteLines.add(item.endLine + 1)
+    }
+
+    result.archived.push({ id: item.id, title: item.title, date: dateStr, year, ageDays: age, archiveFile })
+    result.byFile[archiveFile] = (result.byFile[archiveFile] || 0) + 1
+  }
+
+  if (dryRun || result.archived.length === 0) {
+    return result
+  }
+
+  // Append blocks to each year's archive file (creating the dir/file as needed).
+  fs.mkdirSync(archiveDir, { recursive: true })
+  for (const [file, blocks] of Array.from(appendByFile.entries())) {
+    const exists = fs.existsSync(file)
+    const prior = exists ? fs.readFileSync(file, 'utf-8') : ''
+    const parts: string[] = []
+    if (!exists) {
+      const year = path.basename(file, '.md')
+      parts.push(`# Archived backlog items — ${year}`, '')
+    } else if (prior.length > 0 && !prior.endsWith('\n')) {
+      parts.push('')
+    }
+    for (const block of blocks) {
+      parts.push(block, '')
+    }
+    writeAtomic(file, prior + parts.join('\n'))
+  }
+
+  // Rewrite the inbox without the archived line ranges. Preserve a single
+  // trailing newline so later appends (capture) keep the file tidy, even when
+  // the archived item was the last block and took the final newline with it.
+  const remaining = lines.filter((_, i) => !deleteLines.has(i))
+  let nextInbox = remaining.join('\n')
+  if (nextInbox.length > 0 && !nextInbox.endsWith('\n')) nextInbox += '\n'
+  writeAtomic(inboxPath, nextInbox)
+
+  return result
+}
+
+export function formatArchiveHuman(result: ArchiveResult): string {
+  const out: string[] = []
+  const verb = result.dryRun ? 'Would archive' : 'Archived'
+
+  if (result.archived.length === 0) {
+    out.push(`Nothing to archive — no completed items older than ${result.olderThanDays} day(s).`)
+  } else {
+    out.push(`${verb} ${result.archived.length} completed item(s) older than ${result.olderThanDays} day(s):`)
+    for (const it of result.archived) {
+      out.push(`  + ${it.title} (${it.date}, ${it.ageDays}d) → ${path.basename(it.archiveFile)}`)
+    }
+    const files = Object.keys(result.byFile)
+    if (files.length > 0) {
+      out.push(`Target: ${result.archiveDir}/`)
+    }
+  }
+
+  if (result.skippedRecent.length > 0) {
+    out.push(`Kept ${result.skippedRecent.length} completed item(s) still within the window:`)
+    for (const it of result.skippedRecent) {
+      out.push(`  = ${it.title} (${it.date}, ${it.ageDays}d)`)
+    }
+  }
+  if (result.skippedNoDate.length > 0) {
+    out.push(`Kept ${result.skippedNoDate.length} completed item(s) with no completed::/captured:: date:`)
+    for (const it of result.skippedNoDate) {
+      out.push(`  ? ${it.title}`)
+    }
+  }
+  if (result.dryRun && result.archived.length > 0) {
+    out.push('(dry run — no changes written)')
+  }
+  return out.join('\n')
+}

--- a/cli/inbox-store.ts
+++ b/cli/inbox-store.ts
@@ -201,7 +201,7 @@ export function buildItemBlock(item: InboxItem, updates: ApplyUpdates = {}): str
   return [titleLine, ...fieldLines]
 }
 
-function writeAtomic(filePath: string, content: string): void {
+export function writeAtomic(filePath: string, content: string): void {
   const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`
   fs.writeFileSync(tmp, content, 'utf-8')
   fs.renameSync(tmp, filePath)

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -469,6 +469,31 @@ yargs(hideBin(process.argv))
           },
         )
         .command(
+          'archive',
+          'Move completed inbox items older than N days into a yearly archive file',
+          (yargs) => {
+            return yargs
+              .option('older-than-days', { type: 'number', default: 30, description: 'Archive completed items at least this many days old' })
+              .option('dry-run', { type: 'boolean', default: false, description: 'Preview without writing' })
+          },
+          async (argv) => {
+            try {
+              const { archiveBacklog, formatArchiveHuman } = await import('./commands/backlog-archive')
+              const result = archiveBacklog({
+                olderThanDays: argv['older-than-days'] as number,
+                dryRun: argv['dry-run'] as boolean,
+              })
+              if (argv.json) {
+                output(result, true)
+              } else {
+                output(formatArchiveHuman(result), false)
+              }
+            } catch (err) {
+              errorOut(err instanceof Error ? err.message : String(err), argv.json as boolean)
+            }
+          },
+        )
+        .command(
           'refine',
           'Briefing of unrefined Obsidian inbox items (default), or apply/delete subcommand',
           (yargs) => {


### PR DESCRIPTION
## Summary

Implements **Phase 7 (#21)** — `timebox backlog archive`, a periodic sweep that moves completed (`- [x]`) items out of the working `inbox.md` into a yearly archive file, so the file the refine/plan-day passes read every command doesn't grow forever. Completed work is moved, not deleted (useful for retrospectives/weekly reviews).

Also closes the triage that kicked this off: **#20 (Phase 6)** was verified already-shipped and closed separately.

## Command

```bash
timebox backlog archive [--older-than-days N] [--dry-run] [--json]
```

- **Eligibility by age** — an item is archived once its reference date is at least `N` days in the past (default **30**). The reference date is `completed::`, falling back to `captured::` when completion wasn't stamped.
- **Items with neither date** are left in place and surfaced in the result (`skippedNoDate`) rather than archived blindly.
- **Destination** — `$OBSIDIAN_VAULT_PATH/backlog/archive/<year>.md`, bucketed by the reference date's year. New files get a `# Archived backlog items — <year>` heading.
- **`--dry-run`** previews without writing.
- **Single-pass & safe** — appends blocks to the per-year files, then rewrites the inbox once (so content-hash ids can't drift mid-sweep), preserving a trailing newline. Idempotent / safe to re-run.

## Implementation notes

- New `cli/commands/backlog-archive.ts`; wired into the `backlog` subcommand router in `cli/index.ts` next to `migrate`.
- Reuses the inbox parser (`readInbox`) and exports `writeAtomic` from `cli/inbox-store.ts` for the atomic rewrites.
- `completed::` stamping already landed with Phase 6, so the "optional: track completion date" dependency noted in the issue is satisfied.

## Verification

Exercised against a temp vault covering: eligible-by-`completed::`, eligible-by-`captured::`-fallback, too-recent (kept), completed-with-no-date (kept), pending (untouched), per-year bucketing, `--dry-run` (no writes), idempotent re-run, trailing-newline preservation, missing inbox (graceful no-op), and unset `OBSIDIAN_VAULT_PATH` (clean exit 1). `npx tsc --noEmit` passes clean.

Docs updated in `CLAUDE.md` (backlog table + project structure).

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTxf7RMdeqgCGM8KpK5XJy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTxf7RMdeqgCGM8KpK5XJy)_